### PR TITLE
Fediblock Project 92/Barcelona

### DIFF
--- a/activitypub.domains.block.list.tsv
+++ b/activitypub.domains.block.list.tsv
@@ -38,3 +38,8 @@ kiwifarms.net
 kiwifarms.cc
 kiwifarms.is
 kiwifarms.pleroma.net
+
+# Project 92/Instagram fedi integration (codenamed Barcelona)
+instagram.com
+threads.instagram.com
+threads.net


### PR DESCRIPTION
This PR essentially blocks anything from Meta/Facebook's in-house Instagram federation project, otherwise internally referred to as Project 92/Barcelona. The following (sub-)domains have been blacklisted:

- `instagram.com`
- `threads.instagram.com`
- `threads.net`