### PR TITLE
Adding facebook-compromised instances

### DIFF
--- a/activitypub.domains.block.list.tsv
+++ b/activitypub.domains.block.list.tsv
@@ -43,3 +43,6 @@ kiwifarms.pleroma.net
 instagram.com
 threads.instagram.com
 threads.net
+
+# Project 92-compromised instances
+emacs.ch


### PR DESCRIPTION
Added emacs.ch. Its admin wrote a long apologetic letter shaming those who would block Facebook. 

See https://emacs.ch/@louis/110592744496085427