### PR TITLE
Update activitypub.domains.block.list.tsv

### DIFF
--- a/activitypub.domains.block.list.tsv
+++ b/activitypub.domains.block.list.tsv
@@ -13,7 +13,6 @@ bka.li
 ##	Ban Evasion
 pl.teleyal.blog
 teleyal.blog
-tavern.drow.be
 drow.be
 #	#
 


### PR DESCRIPTION
removed tavern.drow.be (no longer resolvable - it did exist at the time) 
drow.be is fine, however :)

proof attached 
![Screenshot 2024-02-19 194541](https://github.com/greyhat-academy/lists.d/assets/21365310/d999ce62-deb0-4e1c-8aec-da0be041eab5)
