### PR TITLE
Update activitypub.threads.domains.block.list.tsv

### DIFF
--- a/activitypub.threads.domains.block.list.tsv
+++ b/activitypub.threads.domains.block.list.tsv
@@ -27,7 +27,10 @@ emacs.ch
 #	Federating with Threads as per their own admission - previously choose not to.
 mstdn.social
 masto.ai
+mastodon.coffee
 #	#
 
 #	Federating with Threads from the start.
 #	#
+mastodon.social
+mastodon.online


### PR DESCRIPTION
mastodon.coffee should be in the same group as mstdn.social & masto.ai as they are all owned by stux

mastodon.social & mastodon.online have always federated with threads (both owned by Gargron)