### PR TITLE
Added: awakari.com

### DIFF
--- a/activitypub.domains.block.list.tsv
+++ b/activitypub.domains.block.list.tsv
@@ -8,6 +8,7 @@
 ###	Violating consent and scraping content against the explicit wishes of users.
 ###	See:	https://tech.lgbt/@mods/112014491170487904 for details
 contentnation.net
+awakari.com
 
 #	"Kromonos"
 ##	Threatening Maintainers personally with harrassment


### PR DESCRIPTION
awakari.com - operating a data scraper and Fediverse content seller without user consent

Receipts are:
https://mastodon.scot/@gunchleoc/112311149744744675 https://social.beaware.live/@BeAware/112414717311670891 https://awakari.com/articles/awakari-goes-social/index.html