### PR TITLE
+ fsebugoutzone.org, - outpoa.st

### DIFF
--- a/activitypub.domains.block.list.tsv
+++ b/activitypub.domains.block.list.tsv
@@ -86,8 +86,8 @@ s.yelvington.com
 #	reactionary bigotry and hatespeech against magrinalized groups
 poa.st
 freespeechextremist.com
+fsebugoutzone.org
 rdrama.cc
-outpoa.st
 anime.website
 gameliberty.club
 social.byoblu.com


### PR DESCRIPTION
removed outpoa.st - no longer exists

added: fsebugoutzone.org
offshoot of freespeechextremist.com, "freeze peach" instance, has an MRF to block incoming deletes, has a block notification bot

Receipts: https://archive.ph/mOnM9, https://archive.ph/s4lRj, https://archive.ph/kZ1m1