### PR TITLE
Update activitypub.domains.block.list.tsv

### DIFF
--- a/activitypub.domains.block.list.tsv
+++ b/activitypub.domains.block.list.tsv
@@ -153,7 +153,17 @@ catcatnya.com
 #	#
 
 ##	prevent automatic blocks via imported blocklists of accounts hosted on their site.
+colorid.es
+cathode.church
 rage.love
+strangeobject.space
+queer.group
+indiepocalypse.social
+blackqueer.life
+solarpunk.moe
+queer.garden
+tenforward.social
+scholar.social
 weirder.earth
 slime.computer
 solarpunk.moe


### PR DESCRIPTION
Per fedilore: https://mastodon.social/@fedilore/113103669322264291

Adding the other sources of #TheBadSpace blocklist + their supporters.

Sources of TBS are:
mastodon.art
colorid.es
cathode.church
rage.love
strangeobject.space
queer.group
indiepocalypse.social
blackqueer.life
solarpunk.moe
queer.garden

The rest are supporters/cult followers.