### PR TITLE
Update activitypub.domains.block.list.tsv

### DIFF
--- a/activitypub.domains.block.list.tsv
+++ b/activitypub.domains.block.list.tsv
@@ -54,6 +54,7 @@ mastodon.art
 ubiqueros.com
 ###	Ban evasion
 h-i.social
+polychrom.ing
 
 #	BBC
 ##	Blocked for rampant anti-trans propaganda


### PR DESCRIPTION

<img width="601" height="114" alt="Screenshot 2025-08-13 154251" src="https://github.com/user-attachments/assets/f5a2d953-062d-4310-82a0-3c63a0ea1ca1" />

reason: Ro has migrated h-i.social to polychrom.ing (yet another ban evasion)

proof: https://h-i.social/@are0h